### PR TITLE
Use go routines instead of 'concurrently' npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ Quickly spin up your multi command projects.
 
 To run spinup you need to have go installed on your system. You can download it from the [official website](https://golang.org/dl/).
 
-You also need to have `concurrently` installed on your system. You can install it using the following command:
-
-```bash
-sudo npm install -g concurrently
-```
-
-If you don't have nodejs/npm installed you can download it from the [official website](https://www.nodejs.org/).
-
 ### Installation
 
 To install spinup you can use the following command:
@@ -168,6 +160,7 @@ This will run the commands defined in the configuration for the project.
 
 - [x] Commands to add/remove commands from a project.
 - [x] Add option to set the path of the project to use so it can be run anywhere.
+- [x] Don't require `concurrently` to be installed.
 - [ ] Make adding subdomains possible.
 - [ ] Add tests.
 - [ ] Better solution for showing what commands are available.

--- a/spinup/run.go
+++ b/spinup/run.go
@@ -1,11 +1,19 @@
 package spinup
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
+
+type commandWithName struct {
+	command string
+	name    string
+}
 
 func (s *Spinup) commandTemplate(command string, project Project) string {
 	// Replace placeholders in command with project values
@@ -19,10 +27,65 @@ func (s *Spinup) commandTemplate(command string, project Project) string {
 	return command
 }
 
+func (s *Spinup) prefixOutput(prefix string, reader io.Reader, writer io.Writer) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		fmt.Fprintf(writer, "%s %s\n", prefix, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("Error reading output:", err)
+	}
+}
+
+func (s *Spinup) runCommand(wg *sync.WaitGroup, project Project, command commandWithName) {
+	defer wg.Done()
+
+	cmd := exec.Command(strings.Split(command.command, " ")[0], strings.Split(command.command, " ")[1:]...)
+	// Force color output
+	cmd.Env = append(os.Environ(), "FORCE_COLOR=1")
+
+	stdout, err := cmd.StdoutPipe()
+
+	if err != nil {
+		fmt.Println("Error creating StdoutPipe:", err)
+		return
+	}
+
+	stderr, err := cmd.StderrPipe()
+
+	if err != nil {
+		fmt.Println("Error creating StderrPipe:", err)
+		return
+	}
+
+	go s.prefixOutput(fmt.Sprintf("[%s]", command.name), stdout, os.Stdout)
+	go s.prefixOutput(fmt.Sprintf("[%s]", command.name), stderr, os.Stderr)
+
+	// Run the project in the project's directory if it's set
+	if project.Dir != nil {
+		cmd.Dir = *project.Dir
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		fmt.Println("Error starting command:", err)
+		return
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		fmt.Println("Command finished with error:", err)
+		return
+	}
+}
+
 func (s *Spinup) run(project Project, projectName string) {
+	var wg sync.WaitGroup
+	wg.Add(len(project.Commands))
+
 	fmt.Printf("Running project %s\n", projectName)
 
-	commands := []string{}
+	commands := []commandWithName{}
 
 	for _, commandName := range project.Commands {
 		command, err := s.getCommand(commandName)
@@ -32,7 +95,12 @@ func (s *Spinup) run(project Project, projectName string) {
 			os.Exit(1)
 		}
 
-		commands = append(commands, s.commandTemplate(command, project))
+		commands = append(
+			commands,
+			commandWithName{
+				command: s.commandTemplate(command, project),
+				name:    commandName,
+			})
 	}
 
 	if len(commands) == 0 {
@@ -40,15 +108,11 @@ func (s *Spinup) run(project Project, projectName string) {
 		os.Exit(1)
 	}
 
-	concurrent := exec.Command("concurrently", commands...)
-	concurrent.Stdout = os.Stdout
-
-	// Run the project in the project's directory if it's set
-	if project.Dir != nil {
-		concurrent.Dir = *project.Dir
+	for _, command := range commands {
+		go s.runCommand(&wg, project, command)
 	}
 
-	concurrent.Run()
+	wg.Wait()
 }
 
 func (s *Spinup) tryToRun(name string) bool {


### PR DESCRIPTION
Refactor command execution to remove dependency on 'concurrently'. Now using go routines instead