### PR TITLE
Run commands with process groups

### DIFF
--- a/common/helpers.go
+++ b/common/helpers.go
@@ -1,0 +1,7 @@
+package common
+
+import "runtime"
+
+func IsWindows() bool {
+	return runtime.GOOS == "windows"
+}

--- a/core/core.go
+++ b/core/core.go
@@ -18,7 +18,7 @@ import (
 type Core struct {
 	config  *config.Config
 	msgChan *chan common.Msg
-	sigChan chan os.Signal
+	sigChan *chan os.Signal
 
 	out io.Writer
 	err io.Writer
@@ -63,11 +63,11 @@ func WithMsgChan(msgChan *chan common.Msg) func(*Core) {
 	}
 }
 
-func (c *Core) SetOut(out *os.File) {
+func (c *Core) SetOut(out io.Writer) {
 	c.out = out
 }
 
-func (c *Core) SetErr(err *os.File) {
+func (c *Core) SetErr(err io.Writer) {
 	c.err = err
 }
 
@@ -150,8 +150,8 @@ func (c *Core) GetProjectNames() []string {
 	return projectNames
 }
 
-// Get the wait group of the Core instance.
-func (c *Core) GetSigChan() chan os.Signal {
+// Get the signal channel of the Core instance.
+func (c *Core) GetSigChan() *chan os.Signal {
 	return c.sigChan
 }
 

--- a/core/project.go
+++ b/core/project.go
@@ -67,7 +67,7 @@ func (c *Core) AddProject(name string, domain string, port int, commandNames []s
 		_, exists := c.commands[commandName]
 
 		if !exists {
-			return common.NewErrMsg("Command " + commandName + " does not exist")
+			return common.NewErrMsg("Command %s does not exist", commandName)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
+	golang.org/x/sys v0.28.0
 )
 
 require (
@@ -22,6 +23,5 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 )


### PR DESCRIPTION
Use process groups that can be killed of correctly so running processes don't linger around when terminating a project from within the app